### PR TITLE
added redhat(yumrepo) support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,6 +22,9 @@ class fluentd::params {
     'Debian': {
       $repo_manage = true
     }
+    'Redhat': {
+      $repo_manage = true
+    }
     default: {
       fail("Unsupported osfamily: ${::osfamily}")
     }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -6,6 +6,9 @@ class fluentd::repo inherits fluentd {
       'Debian': {
         include ::fluentd::repo::apt
       }
+      'RedHat': {
+        include ::fluentd::repo::yum
+      }
       default: {
         fail("No repo available for ${::osfamily}/${::operatingsystem}")
       }

--- a/manifests/repo/yum.pp
+++ b/manifests/repo/yum.pp
@@ -1,6 +1,7 @@
 # Configure yumrepo
 #
 class fluentd::repo::yum (
+  $ensure   = 'present',
   $descr    = 'TreasureData',
   $baseurl  = 'https://packages.treasuredata.com/2/redhat/$releasever/$basearch',
   $enabled  = '1',
@@ -9,6 +10,7 @@ class fluentd::repo::yum (
 ) {
 
   yumrepo { 'treasure-data':
+    ensure   => $ensure,
     descr    => $descr,
     baseurl  => $baseurl,
     enabled  => $enabled,

--- a/manifests/repo/yum.pp
+++ b/manifests/repo/yum.pp
@@ -8,8 +8,6 @@ class fluentd::repo::yum (
   $gpgkey   = 'https://packages.treasuredata.com/GPG-KEY-td-agent',
 ) {
 
-  include '::yumrepo'
-
   yumrepo { 'treasure-data':
     descr    => $descr,
     baseurl  => $baseurl,

--- a/manifests/repo/yum.pp
+++ b/manifests/repo/yum.pp
@@ -1,0 +1,25 @@
+# Configure yumrepo
+#
+class fluentd::repo::yum (
+  $descr    = 'TreasureData',
+  $baseurl  = 'https://packages.treasuredata.com/2/redhat/$releasever/$basearch',
+  $enabled  = '1',
+  $gpgcheck = '1',
+  $gpgkey   = 'https://packages.treasuredata.com/GPG-KEY-td-agent',
+) {
+
+  include '::yumrepo'
+
+  yumrepo { 'treasure-data':
+    descr    => $descr,
+    baseurl  => $baseurl,
+    enabled  => $enabled,
+    gpgcheck => $gpgcheck,
+    notify   => Exec['add GPG key'],
+  }
+
+  exec { 'add GPG key':
+    command     => "/usr/bin/rpm --import ${fluentd::repo::yum::gpgkey}",
+    refreshonly => true,
+  }
+}


### PR DESCRIPTION
## background
- Please support this osfamily
 - redhat (centos)

### Check CentOS7.2(1511) / Redhat7.1
refs
 - https://td-agent-package-browser.herokuapp.com/2/redhat/
 - http://docs.puppetlabs.com/puppet/latest/reference/type.html#yumrepo

### vagrant test environment
- https://vagrantcloud.com/puppetlabs/boxes/centos-7.2-64-puppet