### PR TITLE
Allow to install specific version of fluent plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,8 @@ This module gives you the possibility to install plugins as gem or files.
 **gem installation**
 ```puppet
 ::fluentd::plugin { 'fluent-plugin-elasticsearch':
-  type => 'gem'
+  type => 'gem',
+  ensure => '0.1.3'
 }
 ```
 **file installation**

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -31,11 +31,6 @@ define fluentd::plugin (
   $source = undef,
 ) {
 
-  # parameter validation
-  if ! ($ensure in [ 'present', 'absent' ]) {
-    fail('ensure parameter must be present or absent')
-  }
-
   case $type {
     'gem': {
       fluentd::plugin::gem { $name:
@@ -44,6 +39,10 @@ define fluentd::plugin (
       }
     }
     'file': {
+      # parameter validation
+      if ! ($ensure in [ 'present', 'absent' ]) {
+        fail('ensure parameter must be present or absent')
+      }
       validate_string($source)
 
       fluentd::plugin::file { $name:

--- a/spec/classes/fluentd_config_spec.rb
+++ b/spec/classes/fluentd_config_spec.rb
@@ -27,6 +27,7 @@ describe 'fluentd::config', :type => :class do
         :lsbdistid       => 'Ubuntu',
         :operatingsystem => 'Ubuntu',
         :lsbdistcodename => 'precise',
+        :architecture    => 'amd64',
       }
     }
 

--- a/spec/classes/fluentd_install_spec.rb
+++ b/spec/classes/fluentd_install_spec.rb
@@ -19,6 +19,7 @@ describe 'fluentd::install', :type => :class do
         :lsbdistid       => 'Ubuntu',
         :operatingsystem => 'Ubuntu',
         :lsbdistcodename => 'precise',
+        :architecture    => 'amd64',
       }
     }
     include_examples 'when called with no parameters'

--- a/spec/classes/fluentd_repo_spec.rb
+++ b/spec/classes/fluentd_repo_spec.rb
@@ -9,6 +9,7 @@ describe 'fluentd::repo', :type => :class do
         :lsbdistid       => 'Ubuntu',
         :operatingsystem => 'Ubuntu',
         :lsbdistcodename => 'precise',
+        :architecture    => 'amd64',
       }
     }
     it {

--- a/spec/classes/fluentd_service_spec.rb
+++ b/spec/classes/fluentd_service_spec.rb
@@ -20,6 +20,7 @@ describe 'fluentd::config', :type => :class do
         :lsbdistid       => 'Ubuntu',
         :operatingsystem => 'Ubuntu',
         :lsbdistcodename => 'precise',
+        :architecture    => 'amd64',
       }
     }
 

--- a/spec/classes/fluentd_spec.rb
+++ b/spec/classes/fluentd_spec.rb
@@ -17,6 +17,7 @@ describe 'fluentd', :type => :class do
         :lsbdistid       => 'Ubuntu',
         :operatingsystem => 'Ubuntu',
         :lsbdistcodename => 'precise',
+        :architecture    => 'amd64',
       }
     }
 

--- a/spec/classes/fluentd_user_spec.rb
+++ b/spec/classes/fluentd_user_spec.rb
@@ -18,6 +18,7 @@ describe 'fluentd::user', :type => :class do
         :lsbdistid       => 'Ubuntu',
         :operatingsystem => 'Ubuntu',
         :lsbdistcodename => 'precise',
+        :architecture    => 'amd64',
       }
     }
 

--- a/spec/defines/filter_spec.rb
+++ b/spec/defines/filter_spec.rb
@@ -7,6 +7,7 @@ describe 'fluentd::filter' do
       :lsbdistid       => 'Ubuntu',
       :operatingsystem => 'Ubuntu',
       :lsbdistcodename => 'precise',
+      :architecture    => 'amd64',
     }
   }
   let(:pre_condition) { 'include fluentd' }

--- a/spec/defines/match_spec.rb
+++ b/spec/defines/match_spec.rb
@@ -7,6 +7,7 @@ describe 'fluentd::match' do
       :lsbdistid       => 'Ubuntu',
       :operatingsystem => 'Ubuntu',
       :lsbdistcodename => 'precise',
+      :architecture    => 'amd64',
     }
   }
   let(:pre_condition) { 'include fluentd' }

--- a/spec/defines/plugin_spec.rb
+++ b/spec/defines/plugin_spec.rb
@@ -7,6 +7,7 @@ describe 'fluentd::plugin' do
       :lsbdistid       => 'Ubuntu',
       :operatingsystem => 'Ubuntu',
       :lsbdistcodename => 'precise',
+      :architecture    => 'amd64',
     }
   }
   let(:pre_condition) { 'include fluentd' }

--- a/spec/defines/source_spec.rb
+++ b/spec/defines/source_spec.rb
@@ -7,6 +7,7 @@ describe 'fluentd::source' do
       :lsbdistid       => 'Ubuntu',
       :operatingsystem => 'Ubuntu',
       :lsbdistcodename => 'precise',
+      :architecture    => 'amd64',
     }
   }
   let(:pre_condition) { 'include fluentd' }


### PR DESCRIPTION
Underlying gem package provider allows to install specific version. It would be nice if `fluentd::plugin` haven't block that option.