### PR TITLE
Change variable names for inner loop in filter.erb

### DIFF
--- a/templates/filter.erb
+++ b/templates/filter.erb
@@ -2,8 +2,8 @@
 <% @config.each do |key, val| -%>
     <%- if val.is_a?( Hash ) -%>
         <<%= key -%>>
-        <%- val.each do |key, val| -%>
-            <%= key -%> <%= val %>
+        <%- val.each do |key2, val2| -%>
+            <%= key2 -%> <%= val2 %>
         <%- end -%>
         </<%= key %>>
     <%- else -%>


### PR DESCRIPTION
When using the module with puppet 3.8.7, ran into an issue where the variable assignment of the inner loop was overwriting the variables of the same name in the outer loop.  This was causing filter configs to be generated with an unmatched record tag.  I have simply changed the names of the variables in the inner loop of the template so that the will no longer occur.