### PR TITLE
Remove old GPG key not working

### DIFF
--- a/manifests/repo/yum.pp
+++ b/manifests/repo/yum.pp
@@ -26,6 +26,7 @@ class fluentd::repo::yum (
 
   exec { 'remove old GPG key':
     command => 'rpm -e --allmatches gpg-pubkey-a12e206f-*',
+    path        => '/bin:/usr/bin/',
     onlyif  => 'rpm -qi gpg-pubkey-a12e206f-*',
     notify  => Exec['add GPG key'],
   }

--- a/manifests/repo/yum.pp
+++ b/manifests/repo/yum.pp
@@ -26,7 +26,7 @@ class fluentd::repo::yum (
 
   exec { 'remove old GPG key':
     command => 'rpm -e --allmatches gpg-pubkey-a12e206f-*',
-    path        => '/bin:/usr/bin/',
+    path    => '/bin:/usr/bin/',
     onlyif  => 'rpm -qi gpg-pubkey-a12e206f-*',
     notify  => Exec['add GPG key'],
   }


### PR DESCRIPTION
Today working with this module in a CentOS 7.3 machine, using Puppet 4.8.1 I received the error:

`Error received before: Error: Failed to apply catalog: Parameter onlyif failed on Exec[remove old GPG key]: 'rpm -qi gpg-pubkey-a12e206f-*' is not qualified and no path was specified. Please qualify the command or specify a path. at /etc/puppetlabs/code/environments/acceptance/modules/fluentd/manifests/repo/yum.pp:27`

I fixed by adding a path. Hope that it is enough.

Cheers.