### PR TITLE
added boolean param for enabling fluentd::conf_dir

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,9 +11,11 @@ class fluentd::config inherits fluentd {
   }
 
   file { $::fluentd::conf_dir:
-    ensure => 'directory',
-    owner  => $::fluentd::user_name,
-    group  => $::fluentd::user_group,
-    mode   => '0750',
+    ensure  => 'directory',
+    recurse => $::fluentd::params::conf_dir_manage,
+    purge   => $::fluentd::params::conf_dir_manage,
+    owner   => $::fluentd::user_name,
+    group   => $::fluentd::user_group,
+    mode    => '0750',
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,9 @@
 # [*repo_manage*]
 #   Include repository to install recent fluentd (td-agent) from
 #   Default: 'true'
+# [*conf_dir_manage*]
+#   Exclusively handle config files into fluentd::conf_dir. Other files not created by puppet, will be deleted
+#   Default: 'false'
 # [*package_ensure*]
 #   Package ensure
 #   Default: 'installed'
@@ -63,6 +66,7 @@ class fluentd (
   $service_enable          = $::fluentd::params::service_enable,
   $config_path             = $::fluentd::params::config_path,
   $conf_dir                = $::fluentd::params::conf_dir,
+  $conf_dir_manage         = $::fluentd::params::conf_dir_manage,
   $config_file             = $::fluentd::params::config_file,
   $user_manage             = $::fluentd::params::user_manage,
   $user_name               = $::fluentd::params::user_name,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,6 +11,7 @@ class fluentd::params {
   # config params
   $config_path = '/etc/td-agent'
   $conf_dir    = "${config_path}/conf.d"
+  $conf_dir_manage = false
   $config_file = "${config_path}/td-agent.conf"
   # user params
   $user_manage = true


### PR DESCRIPTION
This modification is intended to give a class parameter (boolean) that is able to enable/disable the exclusive handling by puppet of the configuration directory. Setting this class params to `true` every fiile created in `::fluentd::conf_dir` not managed by puppet, will be purged.