### PR TITLE
bug in referenced class variable

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,8 +12,8 @@ class fluentd::config inherits fluentd {
 
   file { $::fluentd::conf_dir:
     ensure  => 'directory',
-    recurse => $::fluentd::params::conf_dir_manage,
-    purge   => $::fluentd::params::conf_dir_manage,
+    recurse => $::fluentd::conf_dir_manage,
+    purge   => $::fluentd::conf_dir_manage,
     owner   => $::fluentd::user_name,
     group   => $::fluentd::user_group,
     mode    => '0750',


### PR DESCRIPTION
I wrongly referenced to the default params instead of the class variable. Sorry. Merge this as soon as you can please.