### PR TITLE
Update to td agent 3

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -2,7 +2,7 @@
 #
 class fluentd::repo::apt (
   $ensure       = 'present',
-  $location     = downcase("http://packages.treasuredata.com/2/${::lsbdistid}/${::lsbdistcodename}"),
+  $location     = downcase("http://packages.treasuredata.com/3/${::lsbdistid}/${::lsbdistcodename}"),
   $release      = $::lsbdistcodename,
   $repos        = 'contrib',
   $architecture = $::architecture,

--- a/manifests/repo/yum.pp
+++ b/manifests/repo/yum.pp
@@ -3,7 +3,7 @@
 class fluentd::repo::yum (
   $ensure   = 'present',
   $descr    = 'TreasureData',
-  $baseurl  = 'https://packages.treasuredata.com/2/redhat/$releasever/$basearch',
+  $baseurl  = 'https://packages.treasuredata.com/3/redhat/$releasever/$basearch',
   $enabled  = '1',
   $gpgcheck = '1',
   $gpgkey   = 'https://packages.treasuredata.com/GPG-KEY-td-agent',

--- a/spec/classes/fluentd_repo_apt_spec.rb
+++ b/spec/classes/fluentd_repo_apt_spec.rb
@@ -28,48 +28,62 @@ describe 'fluentd::repo::apt', :type => :class do
         case facts[:operatingsystem]
         when 'Ubuntu'
           case facts[:lsbdistcodename]
+          when 'boinic'
+            it {
+              should contain_apt__source('treasure-data').with({
+                'location'     => 'http://packages.treasuredata.com/3/ubuntu/bionic',
+                'release'      => 'boinic'
+              })
+            }
           when 'precise'
             it {
               should contain_apt__source('treasure-data').with({
-                'location'     => 'http://packages.treasuredata.com/2/ubuntu/precise',
+                'location'     => 'http://packages.treasuredata.com/3/ubuntu/precise',
                 'release'      => 'precise'
               })
             }
           when 'trusty'
             it {
               should contain_apt__source('treasure-data').with({
-                'location'     => 'http://packages.treasuredata.com/2/ubuntu/trusty',
+                'location'     => 'http://packages.treasuredata.com/3/ubuntu/trusty',
                 'release'      => 'trusty'
               })
             }
           when 'xenial'
             it {
               should contain_apt__source('treasure-data').with({
-                'location'     => 'http://packages.treasuredata.com/2/ubuntu/xenial',
+                'location'     => 'http://packages.treasuredata.com/3/ubuntu/xenial',
                 'release'      => 'xenial'
               })
             }
           end
         when 'Debian'
           case facts[:lsbdistcodename]
+          when 'stretch'
+            it {
+              should contain_apt__source('treasure-data').with({
+                'location'     => 'http://packages.treasuredata.com/3/debian/stretch',
+                'release'      => 'stretch'
+              })
+          }
           when 'jessie'
             it {
               should contain_apt__source('treasure-data').with({
-                'location'     => 'http://packages.treasuredata.com/2/debian/jessie',
+                'location'     => 'http://packages.treasuredata.com/3/debian/jessie',
                 'release'      => 'jessie'
               })
           }
           when 'squeeze'
             it {
               should contain_apt__source('treasure-data').with({
-                'location'     => 'http://packages.treasuredata.com/2/debian/squeeze',
+                'location'     => 'http://packages.treasuredata.com/3/debian/squeeze',
                 'release'      => 'squeeze'
               })
             }
           when 'wheezy'
             it {
               should contain_apt__source('treasure-data').with({
-                'location'     => 'http://packages.treasuredata.com/2/debian/wheezy',
+                'location'     => 'http://packages.treasuredata.com/3/debian/wheezy',
                 'release'      => 'wheezy'
               })
             }

--- a/spec/classes/fluentd_repo_yum_spec.rb
+++ b/spec/classes/fluentd_repo_yum_spec.rb
@@ -13,7 +13,7 @@ describe 'fluentd::repo::yum', :type => :class do
           it {
             should contain_yumrepo('treasure-data').with({
               'ensure'   => 'present',
-              'baseurl'  => 'https://packages.treasuredata.com/2/redhat/$releasever/$basearch',
+              'baseurl'  => 'https://packages.treasuredata.com/3/redhat/$releasever/$basearch',
               'descr'    => 'TreasureData',
               'enabled'  => '1',
               'gpgcheck' => '1'


### PR DESCRIPTION
This PR updates the repo configs to use the newer Treasure Data repos containing the 3.x series of td-agents. I had to update to td-agent 3 because the plugins I use all require a more modern Ruby version (>= 2.4) than td-agent 2 provided (Ruby 2.1).